### PR TITLE
Support multiple containers and volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ You can also define a list of volumes and a list of environment variables, which
 When the sidecar injector is installed in your cluster you have to add the `sidecar-injector.ricoberger.de: enabled` label to all namespace, where you want to use the sidecar injector. You also have to set some annotation for your Pods:
 
 - `sidecar-injector.ricoberger.de: enabled`: Enable the sidecar injection for a Pod.
-- `sidecar-injector.ricoberger.de/container: <CONTAINER-NAME>`: Set the name of the container, which should be used from the configuration file.
-- `sidecar-injector.ricoberger.de/volume: <VOLUME-NAME>`: Set the name of the volume, which should be used from the configuration file.
+- `sidecar-injector.ricoberger.de/containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`: Comma-separated list of container names, which should be used from the configuration file.
+- `sidecar-injector.ricoberger.de/volumes: <VOLUME-NAME-1>,<VOLUME-NAME-2>`: Comma-separated list of volume names, which should be used from the configuration file.
 
 ## Test
 

--- a/charts/sidecar-injector/Chart.yaml
+++ b/charts/sidecar-injector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sidecar-injector
 description: Sidecar Injector
 type: application
-version: 0.1.0
-appVersion: v0.1.0
+version: 0.1.1
+appVersion: v0.2.0

--- a/charts/sidecar-injector/values.yaml
+++ b/charts/sidecar-injector/values.yaml
@@ -45,7 +45,7 @@ pod:
 
 image:
   repository: ricoberger/sidecar-injector
-  tag: v0.1.0
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 ## Specify security settings for the sidecar-injector Container. They override settings made at the Pod level via the

--- a/pkg/sidecar/config.go
+++ b/pkg/sidecar/config.go
@@ -9,6 +9,7 @@ import (
 
 type EnvironmentVariable struct {
 	Name       string `yaml:"name"`
+	Container  string `yaml:"container"`
 	Annotation string `yaml:"annotation"`
 }
 

--- a/test/echoserver.yaml
+++ b/test/echoserver.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       annotations:
         sidecar-injector.ricoberger.de: enabled
-        sidecar-injector.ricoberger.de/container: basic-auth
+        sidecar-injector.ricoberger.de/containers: basic-auth
       labels:
         app: echoserver
     spec:


### PR DESCRIPTION
It is now possible to inject multiple containers and volumes into a
single pod. For this we renamed the annotation for the container and
volume name and it is now possible to provide a comma-separated list of
container and volume names via the corresponding annotations.

Environment variables are still supported, but now we must also provide
the container for which the environment variable should be used in the
configuration file.