### PR TITLE
Add support for init containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ When the sidecar injector is installed in your cluster you have to add the `side
 
 - `sidecar-injector.ricoberger.de: enabled`: Enable the sidecar injection for a Pod.
 - `sidecar-injector.ricoberger.de/containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`: Comma-separated list of container names, which should be used from the configuration file.
+- `sidecar-injector.ricoberger.de/init-containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`: Comma-separated list of container names, which should be used from the configuration file as init containers.
 - `sidecar-injector.ricoberger.de/volumes: <VOLUME-NAME-1>,<VOLUME-NAME-2>`: Comma-separated list of volume names, which should be used from the configuration file.
 
 ## Test

--- a/charts/sidecar-injector/Chart.yaml
+++ b/charts/sidecar-injector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sidecar-injector
 description: Sidecar Injector
 type: application
-version: 0.1.1
-appVersion: v0.2.0
+version: 0.1.2
+appVersion: v0.3.0

--- a/charts/sidecar-injector/values.yaml
+++ b/charts/sidecar-injector/values.yaml
@@ -45,7 +45,7 @@ pod:
 
 image:
   repository: ricoberger/sidecar-injector
-  tag: v0.2.0
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 ## Specify security settings for the sidecar-injector Container. They override settings made at the Pod level via the


### PR DESCRIPTION
It is now possible to inject init containers into a Pod via the
"sidecar-injector.ricoberger.de/init-containers" annotation. The
annotation requires a comma-separated list of container names, from the
configuration file. The templates for the init containers can be defined
within the containers section in the config file.