### PR TITLE
:warning: Enable Sidecar Injector for all Namespaces by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ config: |
 
 You can also define a list of volumes and a list of environment variables, which should be set from Pod annotations.
 
-When the sidecar injector is installed in your cluster you have to add the `sidecar-injector.ricoberger.de: enabled` label to all namespace, where you want to use the sidecar injector. You also have to set some annotation for your Pods:
+When the sidecar injector is installed in your cluster you have to set some annotation for your Pods:
 
 - `sidecar-injector.ricoberger.de: enabled`: Enable the sidecar injection for a Pod.
 - `sidecar-injector.ricoberger.de/containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`: Comma-separated list of container names, which should be used from the configuration file.

--- a/charts/sidecar-injector/Chart.yaml
+++ b/charts/sidecar-injector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sidecar-injector
 description: Sidecar Injector
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: v0.6.0

--- a/charts/sidecar-injector/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/sidecar-injector/templates/mutatingwebhookconfiguration.yaml
@@ -20,9 +20,10 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
+    {{- with .Values.namespaceSelector }}
     namespaceSelector:
-      matchLabels:
-        sidecar-injector.ricoberger.de: enabled
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 10

--- a/charts/sidecar-injector/values.yaml
+++ b/charts/sidecar-injector/values.yaml
@@ -112,3 +112,11 @@ topologySpreadConstraints: []
   #   labelSelector:
   #     matchLabels:
   #       app.kubernetes.io/name: sidecar-injector
+
+## Limit which requests for namespaced resources are intercepted by the sidecar-injector, based on the labels of the
+## containing namespace.
+## Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+##
+namespaceSelector: {}
+  # matchLabels:
+  #   sidecar-injector.ricoberger.de: enabled


### PR DESCRIPTION
Instead of explicit setting the "sidecar-injector.ricoberger.de: enabled" label on each namespace where the sidecar injector should be used, the sidecar injector will now watch all namespaces by default.

The sidecar injector can still be limited to specific namespaces by setting the "namespaceSelector" value in the Helm chart.