### PR TITLE
Fix Decoding of Requests

### DIFF
--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var (
@@ -109,8 +110,9 @@ func main() {
 	log.Info("Registering webhooks to the webhook server.")
 	hookServer.Register("/mutate", &webhook.Admission{
 		Handler: &sidecar.Injector{
-			Client: mgr.GetClient(),
-			Config: c,
+			Client:  mgr.GetClient(),
+			Config:  c,
+			Decoder: admission.NewDecoder(mgr.GetScheme()),
 		},
 	})
 

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -27,13 +27,13 @@ const (
 type Injector struct {
 	Client  client.Client
 	Config  *Config
-	decoder *admission.Decoder
+	Decoder *admission.Decoder
 }
 
 func (i *Injector) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 
-	err := i.decoder.Decode(req, pod)
+	err := i.Decoder.Decode(req, pod)
 	if err != nil {
 		log.Error("Could not decode request.", zap.Error(err), zap.String("name", req.Name), zap.String("namespace", req.Namespace))
 		return admission.Errored(http.StatusBadRequest, err)
@@ -99,11 +99,6 @@ func (i *Injector) Handle(ctx context.Context, req admission.Request) admission.
 
 	log.Info("Inject sidecar.", zap.String("name", req.Name), zap.String("namespace", req.Namespace))
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
-}
-
-func (i *Injector) InjectDecoder(d *admission.Decoder) error {
-	i.decoder = d
-	return nil
 }
 
 func getContainer(name string, containers []corev1.Container) (corev1.Container, error) {


### PR DESCRIPTION
There were some breaking changes in the latest controller-runtime update, which brokes the decoder handling. The decoder isn't injected anymore, so that we have to pass a decoder to our injector.