### PR TITLE
Add `failurePolicy` Value

### DIFF
--- a/charts/sidecar-injector/Chart.yaml
+++ b/charts/sidecar-injector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sidecar-injector
 description: Sidecar Injector
 type: application
-version: 0.8.2
+version: 0.9.0
 appVersion: v0.8.2

--- a/charts/sidecar-injector/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/sidecar-injector/templates/mutatingwebhookconfiguration.yaml
@@ -27,3 +27,4 @@ webhooks:
     admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 10
+    failurePolicy: {{ .Values.failurePolicy }}

--- a/charts/sidecar-injector/values.yaml
+++ b/charts/sidecar-injector/values.yaml
@@ -128,3 +128,7 @@ topologySpreadConstraints: []
 namespaceSelector: {}
   # matchLabels:
   #   sidecar-injector.ricoberger.de: enabled
+
+## Set the failure policy for the webhook. Allowed values are "Fail" and "Ignore".
+## Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
+failurePolicy: Fail


### PR DESCRIPTION
Add `failurePolicy` value to the Helm chart to allow users to customize the failure policy of the created webhook.