### PR TITLE
Add ServiceMonitor

### DIFF
--- a/charts/sidecar-injector/Chart.yaml
+++ b/charts/sidecar-injector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sidecar-injector
 description: Sidecar Injector
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: v0.8.2

--- a/charts/sidecar-injector/templates/servicemonitor.yaml
+++ b/charts/sidecar-injector/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "sidecar-injector.fullname" . }}
+  labels:
+    {{- include "sidecar-injector.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+      {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      port: http-metrics
+      path: "/metrics"
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+  jobLabel: {{ include "sidecar-injector.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "sidecar-injector.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{ end }}

--- a/charts/sidecar-injector/values.yaml
+++ b/charts/sidecar-injector/values.yaml
@@ -132,3 +132,13 @@ namespaceSelector: {}
 ## Set the failure policy for the webhook. Allowed values are "Fail" and "Ignore".
 ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
 failurePolicy: Fail
+
+## Create a ServiceMonitor for the Prometheus Operator.
+## Ref: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitor
+serviceMonitor:
+  enabled: false
+  labels: {}
+  interval: 10s
+  scrapeTimeout: 10s
+  honorLabels: true
+  relabelings: []


### PR DESCRIPTION
Add ServiceMonitor to Helm chart, so that the service can be monitored via Prometheus Operator.