### PR TITLE
Add GitHub Container Registry

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Docker Image (webhook)
         id: docker_build_webhook
         uses: docker/build-push-action@v6
@@ -46,7 +53,11 @@ jobs:
           context: .
           file: ./cmd/webhook/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
-          tags: ricoberger/sidecar-injector:${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}
+            ricoberger/sidecar-injector:${{ env.TAG }}
 
       - name: Build and Push Docker Image (basicauth)
         id: docker_build_basicauth
@@ -56,4 +67,8 @@ jobs:
           context: .
           file: ./cmd/basicauth/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
-          tags: ricoberger/sidecar-injector:${{ env.TAG }}-basicauth
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}-basicauth
+            ricoberger/sidecar-injector:${{ env.TAG }}-basicauth

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The configuration for the injected sidecars can be passed to the sidecar injecto
 config: |
   containers:
     - name: basic-auth
-      image: ricoberger/sidecar-injector:basic-auth
+      image: ghrc.io/ricoberger/sidecar-injector:basic-auth
       imagePullPolicy: Always
       env:
         - name: BASIC_AUTH_PASSWORD

--- a/charts/sidecar-injector/Chart.yaml
+++ b/charts/sidecar-injector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sidecar-injector
 description: Sidecar Injector
 type: application
-version: 0.10.2
-appVersion: v0.8.4
+version: 0.10.3
+appVersion: v0.9.0

--- a/charts/sidecar-injector/values.yaml
+++ b/charts/sidecar-injector/values.yaml
@@ -44,8 +44,8 @@ pod:
   labels: {}
 
 image:
-  repository: ricoberger/sidecar-injector
-  tag: v0.8.4
+  repository: ghcr.io/ricoberger/sidecar-injector
+  tag: v0.9.0
   pullPolicy: IfNotPresent
 
 ## Specify security settings for the sidecar-injector Container. They override settings made at the Pod level via the


### PR DESCRIPTION
Add the Docker image to the GitHub Container Registry as alternative to DockerHub and make GHCR the default in the Helm chart.

This commit also adds the `cache-from` and `cache-to` parameters to the GitHub Action to build the Docker image.