### PR TITLE
Add GitHub Auth Service

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,17 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "docker"
+    directory: "/cmd/githubauth"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "ricoberger"
+    groups:
+      docker-bacsicauth:
+        patterns:
+          - "*"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -72,3 +72,17 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.TAG }}-basicauth
             ricoberger/sidecar-injector:${{ env.TAG }}-basicauth
+
+      - name: Build and Push Docker Image (githubauth)
+        id: docker_build_githubauth
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ./cmd/githubauth/Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}-githubauth
+            ricoberger/sidecar-injector:${{ env.TAG }}-githubauth

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -32,3 +32,4 @@ jobs:
         run: |
           make build-webhook
           make build-basicauth
+          make build-githubauth

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ build-basicauth:
 		-X ${REPO}/pkg/version.BuildUser=${BUILDUSER} \
 		-X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
 		-o ./bin/basicauth ./cmd/basicauth;
+
+build-githubauth:
+	@go build -ldflags "-X ${REPO}/pkg/version.Version=${VERSION} \
+		-X ${REPO}/pkg/version.Revision=${REVISION} \
+		-X ${REPO}/pkg/version.Branch=${BRANCH} \
+		-X ${REPO}/pkg/version.BuildUser=${BUILDUSER} \
+		-X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
+		-o ./bin/githubauth ./cmd/githubauth;

--- a/cmd/basicauth/Dockerfile
+++ b/cmd/basicauth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0 as build
+FROM golang:1.23.0 AS build
 WORKDIR /basicauth
 COPY go.mod go.sum ./
 RUN go mod download

--- a/cmd/githubauth/Dockerfile
+++ b/cmd/githubauth/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.23.0 AS build
+WORKDIR /githubauth
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN export CGO_ENABLED=0 && make build-githubauth
+
+FROM alpine:3.20.2
+RUN apk update && apk add --no-cache ca-certificates
+RUN mkdir /githubauth
+COPY --from=build /githubauth/bin/githubauth /githubauth
+WORKDIR /githubauth
+USER nobody
+ENTRYPOINT  [ "/githubauth/githubauth" ]

--- a/cmd/webhook/Dockerfile
+++ b/cmd/webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0 as build
+FROM golang:1.23.0 AS build
 WORKDIR /webhook
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.22.2
 
 require (
+	github.com/google/go-github/v65 v65.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.31.1
@@ -32,6 +33,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,9 +38,14 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v65 v65.0.0 h1:pQ7BmO3DZivvFk92geC0jB0q2m3gyn8vnYPgV7GSLhQ=
+github.com/google/go-github/v65 v65.0.0/go.mod h1:DvrqWo5hvsdhJvHd4WyVF9ttANN3BniqjP8uTFMNb60=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=


### PR DESCRIPTION
The GitHub auth service can be used to authenticate a user with a username and personal access token send in the `Authorization` header, if the user is a member in an organization provided via the `GITHUB_ORGANIZATION` environment variable.