### PR TITLE
Add `injectors` Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,31 @@
 # Sidecar Injector
 
-The sidecar injector can be used to inject a sidecar into a Pod via a [Mutating Webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
+The sidecar injector can be used to inject a sidecar into a Pod via a
+[Mutating Webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
 
 ## Usage
 
-The sidecar injector can be installed via Helm. To use the Helm [cert-manager](https://cert-manager.io) is required.
+The sidecar injector can be installed via Helm. To use the Helm
+[cert-manager](https://cert-manager.io) is required.
 
 ```sh
 helm upgrade --install sidecar-injector oci://ghcr.io/ricoberger/charts/sidecar-injector --version 1.0.0
 ```
 
-The configuration for the injected sidecars can be passed to the sidecar injector via the `config` value in the Helm chart. The following configuration injects the basic auth sidecar:
+The configuration for the injected sidecars can be passed to the sidecar
+injector via the `config` value in the Helm chart. The following configuration
+injects the basic auth sidecar:
 
 ```yaml
 config: |
+  injectors:
+    selector:
+      matchLabels:
+        useBasicAuth: "true"
+    containers:
+      - basic-auth
+    initContainers: []
+    volumes: []
   containers:
     - name: basic-auth
       image: ghrc.io/ricoberger/sidecar-injector:basic-auth
@@ -55,18 +67,34 @@ config: |
   environmentVariables: []
 ```
 
-You can also define a list of volumes and a list of environment variables, which should be set from Pod annotations.
+You can also define a list of volumes and a list of environment variables, which
+should be set from Pod annotations.
 
-When the sidecar injector is installed in your cluster you have to set some annotation for your Pods:
+When the sidecar injector is installed in your cluster you have to set some
+annotation for your Pods:
 
-- `sidecar-injector.ricoberger.de: enabled`: Enable the sidecar injection for a Pod.
-- `sidecar-injector.ricoberger.de/containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`: Comma-separated list of container names, which should be used from the configuration file.
-- `sidecar-injector.ricoberger.de/init-containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`: Comma-separated list of container names, which should be used from the configuration file as init containers.
-- `sidecar-injector.ricoberger.de/volumes: <VOLUME-NAME-1>,<VOLUME-NAME-2>`: Comma-separated list of volume names, which should be used from the configuration file.
+- `sidecar-injector.ricoberger.de: enabled`: Enable the sidecar injection for a
+  Pod.
+- `sidecar-injector.ricoberger.de/containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`:
+  Comma-separated list of container names, which should be used from the
+  configuration file.
+- `sidecar-injector.ricoberger.de/init-containers: <CONTAINER-NAME-1>,<CONTAINER-NAME-2>`:
+  Comma-separated list of container names, which should be used from the
+  configuration file as init containers.
+- `sidecar-injector.ricoberger.de/volumes: <VOLUME-NAME-1>,<VOLUME-NAME-2>`:
+  Comma-separated list of volume names, which should be used from the
+  configuration file.
+
+The sidecars which should be injected can also be defined via the `injectors`
+field in the configuration. This can be used to inject sidecars without the need
+of defining them via annotations. Instead the `selector` can be used to defined
+the Pods which should have a sidecar injected.
 
 ### Environment Variables
 
-It is possible to set additional environment variables for the injected sidecar via annotations. The environment variables which can be injected must be defined in the `environmentVariables` section in the config, e.g.
+It is possible to set additional environment variables for the injected sidecar
+via annotations. The environment variables which can be injected must be defined
+in the `environmentVariables` section in the config, e.g.
 
 ```yaml
 config: |
@@ -76,7 +104,9 @@ config: |
       annotation: sidecar-injector.ricoberger.de/envname
 ```
 
-With this configuration a user can then use the `sidecar-injector.ricoberger.de/envname` annotation to set the value of the `ENV_NAME` environment variable in the specified `<CONTAINER-NAME>`:
+With this configuration a user can then use the
+`sidecar-injector.ricoberger.de/envname` annotation to set the value of the
+`ENV_NAME` environment variable in the specified `<CONTAINER-NAME>`:
 
 ```yaml
 ---
@@ -98,7 +128,9 @@ spec:
 
 ### Resources
 
-Since the injected sidecars might need different resources depending on the service where they are injected it is also possible to overwrite the CPU Requests / Limits and Memory Requests and Limits via an annotation:
+Since the injected sidecars might need different resources depending on the
+service where they are injected it is also possible to overwrite the CPU
+Requests / Limits and Memory Requests and Limits via an annotation:
 
 - `sidecar-injector.ricoberger.de/containers/<CONTAINER-NAME>/cpurequests`
 - `sidecar-injector.ricoberger.de/containers/<CONTAINER-NAME>/cpulimits`

--- a/pkg/sidecar/config.go
+++ b/pkg/sidecar/config.go
@@ -4,8 +4,16 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
+
+type InjectorData struct {
+	Selector       metav1.LabelSelector `yaml:"selector"`
+	Containers     []string             `yaml:"container"`
+	InitContainers []string             `yaml:"initContainers"`
+	Volumes        []string             `yaml:"volumes"`
+}
 
 type EnvironmentVariable struct {
 	Name       string `yaml:"name"`
@@ -14,6 +22,7 @@ type EnvironmentVariable struct {
 }
 
 type Config struct {
+	Injectors            []InjectorData        `yaml:"injectors"`
 	Containers           []corev1.Container    `yaml:"containers"`
 	Volumes              []corev1.Volume       `yaml:"volumes"`
 	EnvironmentVariables []EnvironmentVariable `yaml:"environmentVariables"`

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -9,6 +9,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -32,6 +34,67 @@ type Injector struct {
 	Decoder admission.Decoder
 }
 
+func (i *Injector) getResourcesToInject(req admission.Request, pod *corev1.Pod) ([]string, []string, []string, bool, error) {
+	var initContainers []string
+	var containers []string
+	var volumes []string
+
+	// If the Pod already has the annotation
+	// `sidecar-injector.ricoberger.de/status` set to `injected` we can skip the
+	// injection of resources, because this was already done.
+	if val, ok := pod.Annotations[annotationStatusKey]; ok && val == "injected" {
+		log.Info("Already injected.", "name", req.Name, "namespace", req.Namespace)
+		return nil, nil, nil, false, nil
+	}
+
+	// Check if the Pod matches an defined injector, by comparing the labels of
+	// the Pod with the defined selector of the injector definition. If the Pod
+	// matches the selector we add the defined resources in the injector to the
+	// list of resources which should be injected.
+	for _, injector := range i.Config.Injectors {
+		selector, err := metav1.LabelSelectorAsSelector(&injector.Selector)
+		if err != nil {
+			log.Error(err, "Failed to convert label selector to selector.", "name", req.Name, "namespace", req.Namespace)
+			return nil, nil, nil, false, err
+		}
+
+		if selector.Matches(labels.Set(pod.Labels)) {
+			initContainers = injector.InitContainers
+			containers = injector.Containers
+			volumes = injector.Volumes
+		}
+	}
+
+	// Check if the Pod has the `sidecar-injector.ricoberger.de` annotation,
+	// which means that the resources which should be injected are defined
+	// within the annotations of the Pod.
+	//
+	// If the Pod doesn't have the label and didn't matched any of the defined
+	// injectors from the config, we can skip the injection of sidecars.
+	if val, ok := pod.Annotations[annotationInjectKey]; (!ok || val != "enabled") && (len(initContainers) == 0 && len(containers) == 0 && len(volumes) == 0) {
+		log.Info("No injection required.", "name", req.Name, "namespace", req.Namespace)
+		return nil, nil, nil, false, nil
+	}
+
+	// Check the sidecar injector annotations of the Pod and add the defined
+	// Init Containers, Containers and Volumes to the lists of resources, which
+	// should be injected into the Pod.
+	if initContainerNames, ok := pod.Annotations[annotationInitContainersKey]; ok && initContainerNames != "" {
+		initContainers = append(initContainers, strings.Split(initContainerNames, ",")...)
+	}
+
+	if containerNames, ok := pod.Annotations[annotationContainersKey]; ok && containerNames != "" {
+		containers = append(containers, strings.Split(containerNames, ",")...)
+	}
+
+	if volumeNames, ok := pod.Annotations[annotationVolumesKey]; ok && volumeNames != "" {
+		volumes = append(volumes, strings.Split(volumeNames, ",")...)
+	}
+
+	return initContainers, containers, volumes, true, nil
+
+}
+
 func (i *Injector) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 
@@ -41,54 +104,47 @@ func (i *Injector) Handle(ctx context.Context, req admission.Request) admission.
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if val, ok := pod.Annotations[annotationInjectKey]; !ok || val != "enabled" {
-		log.Info("No injection required.", "name", req.Name, "namespace", req.Namespace)
+	initContainers, containers, volumes, inject, err := i.getResourcesToInject(req, pod)
+	if err != nil {
+		log.Error(err, "Failed to get resources to inject.", "name", req.Name, "namespace", req.Namespace)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if !inject {
 		return admission.Allowed("No injection required.")
 	}
 
-	if val, ok := pod.Annotations[annotationStatusKey]; ok && val == "injected" {
-		log.Info("Already injected.", "name", req.Name, "namespace", req.Namespace)
-		return admission.Allowed("Already injected.")
+	for _, initContainerName := range initContainers {
+		container, err := getContainer(initContainerName, i.Config.Containers)
+		if err != nil {
+			log.Error(err, "Init-Container was not found.", "name", req.Name, "namespace", req.Namespace, "init-container", initContainerName)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		container = addEnvVariables(container, pod.Annotations, i.Config.EnvironmentVariables)
+		container = setResources(container, annotationInitContainersKey, pod.Annotations)
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
 	}
 
-	if initContainerNames, ok := pod.Annotations[annotationInitContainersKey]; ok && initContainerNames != "" {
-		for _, initContainerName := range strings.Split(initContainerNames, ",") {
-			container, err := getContainer(initContainerName, i.Config.Containers)
-			if err != nil {
-				log.Error(err, "Init-Container was not found.", "name", req.Name, "namespace", req.Namespace, "init-container", initContainerName)
-				return admission.Errored(http.StatusBadRequest, err)
-			}
-
-			container = addEnvVariables(container, pod.Annotations, i.Config.EnvironmentVariables)
-			container = setResources(container, annotationInitContainersKey, pod.Annotations)
-			pod.Spec.InitContainers = append(pod.Spec.InitContainers, container)
+	for _, containerName := range containers {
+		container, err := getContainer(containerName, i.Config.Containers)
+		if err != nil {
+			log.Error(err, "Container was not found.", "name", req.Name, "namespace", req.Namespace, "container", containerName)
+			return admission.Errored(http.StatusBadRequest, err)
 		}
+
+		container = addEnvVariables(container, pod.Annotations, i.Config.EnvironmentVariables)
+		container = setResources(container, annotationContainersKey, pod.Annotations)
+		pod.Spec.Containers = append(pod.Spec.Containers, container)
 	}
 
-	if containerNames, ok := pod.Annotations[annotationContainersKey]; ok && containerNames != "" {
-		for _, containerName := range strings.Split(containerNames, ",") {
-			container, err := getContainer(containerName, i.Config.Containers)
-			if err != nil {
-				log.Error(err, "Container was not found.", "name", req.Name, "namespace", req.Namespace, "container", containerName)
-				return admission.Errored(http.StatusBadRequest, err)
-			}
-
-			container = addEnvVariables(container, pod.Annotations, i.Config.EnvironmentVariables)
-			container = setResources(container, annotationContainersKey, pod.Annotations)
-			pod.Spec.Containers = append(pod.Spec.Containers, container)
+	for _, volumeName := range volumes {
+		volume, err := getVolume(volumeName, i.Config.Volumes)
+		if err != nil {
+			log.Error(err, "Volume was not found.", "name", req.Name, "namespace", req.Namespace, "volume", volumeName)
+			return admission.Errored(http.StatusBadRequest, err)
 		}
-	}
 
-	if volumeNames, ok := pod.Annotations[annotationVolumesKey]; ok && volumeNames != "" {
-		for _, volumeName := range strings.Split(volumeNames, ",") {
-			volume, err := getVolume(volumeName, i.Config.Volumes)
-			if err != nil {
-				log.Error(err, "Volume was not found.", "name", req.Name, "namespace", req.Namespace, "volume", volumeName)
-				return admission.Errored(http.StatusBadRequest, err)
-			}
-
-			pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
-		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
 	}
 
 	pod.Annotations[annotationStatusKey] = "injected"


### PR DESCRIPTION
Until now it was only possible to inject sidecars into a Pod, when the
Pod had the `sidecar-injector.ricoberger.de` annotation. With the new
`injectors` configuration it is now possible to inject sidecars by
defining them in the configuration. When defined the sidecars will be
injected into all Pods which are matching the `selectors` configuration,
so that the Pod must not have the `sidecar-injector.ricoberger.de`
annotation anymore.
