### PR TITLE
Add Tests for Sidecar Injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ Since the injected sidecars might need different resources depending on the
 service where they are injected it is also possible to overwrite the CPU
 Requests / Limits and Memory Requests and Limits via an annotation:
 
-- `sidecar-injector.ricoberger.de/containers/<CONTAINER-NAME>/cpurequests`
-- `sidecar-injector.ricoberger.de/containers/<CONTAINER-NAME>/cpulimits`
-- `sidecar-injector.ricoberger.de/containers/<CONTAINER-NAME>/memoryrequests`
-- `sidecar-injector.ricoberger.de/containers/<CONTAINER-NAME>/memorylimits`
+- `sidecar-injector.ricoberger.de/containers-<CONTAINER-NAME>-cpurequests`
+- `sidecar-injector.ricoberger.de/containers-<CONTAINER-NAME>-cpulimits`
+- `sidecar-injector.ricoberger.de/containers-<CONTAINER-NAME>-memoryrequests`
+- `sidecar-injector.ricoberger.de/containers-<CONTAINER-NAME>-memorylimits`
 
 The same can be done for init containers by using the following annotations:
 
-- `sidecar-injector.ricoberger.de/init-containers/<CONTAINER-NAME>/cpurequests`
-- `sidecar-injector.ricoberger.de/init-containers/<CONTAINER-NAME>/cpulimits`
-- `sidecar-injector.ricoberger.de/init-containers/<CONTAINER-NAME>/memoryrequests`
-- `sidecar-injector.ricoberger.de/init-containers/<CONTAINER-NAME>/memorylimits`
+- `sidecar-injector.ricoberger.de/init-containers-<CONTAINER-NAME>-cpurequests`
+- `sidecar-injector.ricoberger.de/init-containers-<CONTAINER-NAME>-cpulimits`
+- `sidecar-injector.ricoberger.de/init-containers-<CONTAINER-NAME>-memoryrequests`
+- `sidecar-injector.ricoberger.de/init-containers-<CONTAINER-NAME>-memorylimits`

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.24.0
 require (
 	github.com/google/go-github/v65 v65.0.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/onsi/ginkgo/v2 v2.22.0
+	github.com/onsi/gomega v1.36.1
 	github.com/spf13/pflag v1.0.6
-	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.32.2
 	k8s.io/apimachinery v0.32.2
 	k8s.io/client-go v0.32.2
@@ -27,12 +28,15 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -41,25 +45,28 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
+	golang.org/x/tools v0.26.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -1,0 +1,434 @@
+package sidecar
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Sidecar", func() {
+	Context("Creating and updating Pods", func() {
+		It("Should inject sidecar into Pods which are matching selector from injector configuration", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"sidecar-injector": "injector-test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-1", Namespace: "default"}, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pod.Annotations[annotationStatusKey]).To(Equal("injected"))
+			Expect(len(pod.Spec.InitContainers)).To(Equal(1))
+			Expect(len(pod.Spec.Containers)).To(Equal(2))
+			Expect(len(pod.Spec.Volumes)).To(Equal(1))
+			Expect(pod.Spec.Containers[1].Name).To(Equal("test-container"))
+			Expect(pod.Spec.Containers[1].Resources.Requests["cpu"]).To(Equal(resource.MustParse("100m")))
+			Expect(pod.Spec.Containers[1].Resources.Requests["memory"]).To(Equal(resource.MustParse("100Mi")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["cpu"]).To(Equal(resource.MustParse("200m")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["memory"]).To(Equal(resource.MustParse("200Mi")))
+			Expect(len(pod.Spec.Containers[1].Env)).To(Equal(0))
+
+			By("Update Pod")
+			podWithSidecar := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-1", Namespace: "default"}, podWithSidecar)
+			Expect(err).NotTo(HaveOccurred())
+
+			podWithSidecar.Labels["newlabel"] = "newlabel"
+			err = k8sClient.Update(ctx, podWithSidecar)
+			Expect(err).NotTo(HaveOccurred())
+
+			podUpdated := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-1", Namespace: "default"}, podUpdated)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(podUpdated.Annotations[annotationStatusKey]).To(Equal("injected"))
+			Expect(len(podUpdated.Spec.InitContainers)).To(Equal(1))
+			Expect(len(podUpdated.Spec.Containers)).To(Equal(2))
+			Expect(len(podUpdated.Spec.Volumes)).To(Equal(1))
+			Expect(podUpdated.Spec.Containers[1].Name).To(Equal("test-container"))
+			Expect(podUpdated.Spec.Containers[1].Resources.Requests["cpu"]).To(Equal(resource.MustParse("100m")))
+			Expect(podUpdated.Spec.Containers[1].Resources.Requests["memory"]).To(Equal(resource.MustParse("100Mi")))
+			Expect(podUpdated.Spec.Containers[1].Resources.Limits["cpu"]).To(Equal(resource.MustParse("200m")))
+			Expect(podUpdated.Spec.Containers[1].Resources.Limits["memory"]).To(Equal(resource.MustParse("200Mi")))
+			Expect(len(podUpdated.Spec.Containers[1].Env)).To(Equal(0))
+		})
+
+		It("Should inject sidecar into Pods which have sidecar-injector annotation", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-2",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationInjectKey:         "enabled",
+						annotationContainersKey:     "test-container",
+						annotationInitContainersKey: "test-initcontainer",
+						annotationVolumesKey:        "test-volume",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-2", Namespace: "default"}, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pod.Annotations[annotationStatusKey]).To(Equal("injected"))
+			Expect(len(pod.Spec.InitContainers)).To(Equal(1))
+			Expect(len(pod.Spec.Containers)).To(Equal(2))
+			Expect(len(pod.Spec.Volumes)).To(Equal(1))
+			Expect(pod.Spec.Containers[1].Name).To(Equal("test-container"))
+			Expect(pod.Spec.Containers[1].Resources.Requests["cpu"]).To(Equal(resource.MustParse("100m")))
+			Expect(pod.Spec.Containers[1].Resources.Requests["memory"]).To(Equal(resource.MustParse("100Mi")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["cpu"]).To(Equal(resource.MustParse("200m")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["memory"]).To(Equal(resource.MustParse("200Mi")))
+			Expect(len(pod.Spec.Containers[1].Env)).To(Equal(0))
+		})
+
+		It("Should inject sidecar into Pods with updated resources", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-3",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationInjectKey:     "enabled",
+						annotationContainersKey: "test-container",
+						"sidecar-injector.ricoberger.de/containers-test-container-cpurequests":    "200m",
+						"sidecar-injector.ricoberger.de/containers-test-container-cpulimits":      "300m",
+						"sidecar-injector.ricoberger.de/containers-test-container-memoryrequests": "200Mi",
+						"sidecar-injector.ricoberger.de/containers-test-container-memorylimits":   "300Mi",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-3", Namespace: "default"}, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pod.Annotations[annotationStatusKey]).To(Equal("injected"))
+			Expect(len(pod.Spec.InitContainers)).To(Equal(0))
+			Expect(len(pod.Spec.Containers)).To(Equal(2))
+			Expect(len(pod.Spec.Volumes)).To(Equal(0))
+			Expect(pod.Spec.Containers[1].Name).To(Equal("test-container"))
+			Expect(pod.Spec.Containers[1].Resources.Requests["cpu"]).To(Equal(resource.MustParse("200m")))
+			Expect(pod.Spec.Containers[1].Resources.Requests["memory"]).To(Equal(resource.MustParse("200Mi")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["cpu"]).To(Equal(resource.MustParse("300m")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["memory"]).To(Equal(resource.MustParse("300Mi")))
+			Expect(len(pod.Spec.Containers[1].Env)).To(Equal(0))
+		})
+
+		It("Should inject sidecar into Pods with additional environment variables", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-4",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationInjectKey:                           "enabled",
+						annotationContainersKey:                       "test-container",
+						"sidecar-injector.ricoberger.de/test-env-var": "test-env-var-value",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-4", Namespace: "default"}, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pod.Annotations[annotationStatusKey]).To(Equal("injected"))
+			Expect(len(pod.Spec.InitContainers)).To(Equal(0))
+			Expect(len(pod.Spec.Containers)).To(Equal(2))
+			Expect(len(pod.Spec.Volumes)).To(Equal(0))
+			Expect(pod.Spec.Containers[1].Name).To(Equal("test-container"))
+			Expect(pod.Spec.Containers[1].Resources.Requests["cpu"]).To(Equal(resource.MustParse("100m")))
+			Expect(pod.Spec.Containers[1].Resources.Requests["memory"]).To(Equal(resource.MustParse("100Mi")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["cpu"]).To(Equal(resource.MustParse("200m")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["memory"]).To(Equal(resource.MustParse("200Mi")))
+			Expect(len(pod.Spec.Containers[1].Env)).To(Equal(1))
+		})
+
+		It("Should fail when container name is invalid", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-5",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationInjectKey:     "enabled",
+						annotationContainersKey: "test-container-invalid",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should fail when init container name is invalid", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-5",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationInjectKey:         "enabled",
+						annotationInitContainersKey: "test-container-invalid",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should fail when volume name is invalid", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-5",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationInjectKey:  "enabled",
+						annotationVolumesKey: "test-volume-invalid",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should inject sidecar into Pods and ignore invalid resource annotations", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-6",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationInjectKey:     "enabled",
+						annotationContainersKey: "test-container",
+						"sidecar-injector.ricoberger.de/containers-test-container-cpurequests":    "invalid",
+						"sidecar-injector.ricoberger.de/containers-test-container-cpulimits":      "invalid",
+						"sidecar-injector.ricoberger.de/containers-test-container-memoryrequests": "invalid",
+						"sidecar-injector.ricoberger.de/containers-test-container-memorylimits":   "invalid",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-6", Namespace: "default"}, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pod.Annotations[annotationStatusKey]).To(Equal("injected"))
+			Expect(len(pod.Spec.InitContainers)).To(Equal(0))
+			Expect(len(pod.Spec.Containers)).To(Equal(2))
+			Expect(len(pod.Spec.Volumes)).To(Equal(0))
+			Expect(pod.Spec.Containers[1].Name).To(Equal("test-container"))
+			Expect(pod.Spec.Containers[1].Resources.Requests["cpu"]).To(Equal(resource.MustParse("100m")))
+			Expect(pod.Spec.Containers[1].Resources.Requests["memory"]).To(Equal(resource.MustParse("100Mi")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["cpu"]).To(Equal(resource.MustParse("200m")))
+			Expect(pod.Spec.Containers[1].Resources.Limits["memory"]).To(Equal(resource.MustParse("200Mi")))
+			Expect(len(pod.Spec.Containers[1].Env)).To(Equal(0))
+		})
+
+		It("Should do nothing if pod does not require injection", func() {
+			By("Create Pod")
+			err := k8sClient.Create(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-7",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "my-container",
+							Image:           "my-image",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("150m"),
+									"memory": resource.MustParse("150Mi"),
+								},
+								Limits: corev1.ResourceList{
+									"cpu":    resource.MustParse("250m"),
+									"memory": resource.MustParse("250Mi"),
+								},
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-pod-7", Namespace: "default"}, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pod.Annotations).To(BeNil())
+			Expect(len(pod.Spec.InitContainers)).To(Equal(0))
+			Expect(len(pod.Spec.Containers)).To(Equal(1))
+			Expect(len(pod.Spec.Volumes)).To(Equal(0))
+		})
+	})
+})

--- a/pkg/sidecar/suite_test.go
+++ b/pkg/sidecar/suite_test.go
@@ -1,0 +1,217 @@
+package sidecar
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("Bootstrapping test environment")
+
+	failurePolicy := admissionv1.Fail
+	path := "/mutate"
+	sideEffects := admissionv1.SideEffectClassNone
+
+	testEnv = &envtest.Environment{
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			MutatingWebhooks: []*admissionv1.MutatingWebhookConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "sidecar-injector",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "MutatingWebhookConfiguration",
+						APIVersion: "admissionregistration.k8s.io/v1",
+					},
+					Webhooks: []admissionv1.MutatingWebhook{
+						{
+							Name:                    "sidecar-injector.ricoberger.de",
+							AdmissionReviewVersions: []string{"v1"},
+							FailurePolicy:           &failurePolicy,
+							ClientConfig: admissionv1.WebhookClientConfig{
+								Service: &admissionv1.ServiceReference{
+									Path: &path,
+								},
+							},
+							Rules: []admissionv1.RuleWithOperations{
+								{
+									Operations: []admissionv1.OperationType{
+										admissionv1.Create,
+										admissionv1.Update,
+									},
+									Rule: admissionv1.Rule{
+										APIGroups:   []string{""},
+										APIVersions: []string{"v1"},
+										Resources:   []string{"pods"},
+									},
+								},
+							},
+							SideEffects: &sideEffects,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	scheme := apimachineryruntime.NewScheme()
+	err = clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = admissionv1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	mgr.GetWebhookServer().Register("/mutate", &webhook.Admission{
+		Handler: &Injector{
+			Client: mgr.GetClient(),
+			Config: &Config{
+				Injectors: []InjectorData{
+					{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"sidecar-injector": "injector-test",
+							},
+						},
+						Containers:     []string{"test-container"},
+						InitContainers: []string{"test-initcontainer"},
+						Volumes:        []string{"test-volume"},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:            "test-container",
+						Image:           "test-image",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"cpu":    resource.MustParse("100m"),
+								"memory": resource.MustParse("100Mi"),
+							},
+							Limits: corev1.ResourceList{
+								"cpu":    resource.MustParse("200m"),
+								"memory": resource.MustParse("200Mi"),
+							},
+						},
+					},
+					{
+						Name:            "test-initcontainer",
+						Image:           "test-initimage",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"cpu":    resource.MustParse("50m"),
+								"memory": resource.MustParse("50Mi"),
+							},
+							Limits: corev1.ResourceList{
+								"cpu":    resource.MustParse("50m"),
+								"memory": resource.MustParse("50Mi"),
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "secret-config",
+							},
+						},
+					},
+				},
+				EnvironmentVariables: []EnvironmentVariable{
+					{
+						Name:       "test-env-var",
+						Container:  "test-container",
+						Annotation: "sidecar-injector.ricoberger.de/test-env-var",
+					},
+				},
+			},
+			Decoder: admission.NewDecoder(mgr.GetScheme()),
+		},
+	})
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		//nolint:gosec
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("Tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -5,38 +5,49 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestPrint(t *testing.T) {
-	goVersion := runtime.Version()
-
-	Version = "v0.4.0"
-	Revision = "cc373f263575773f1349bbd354e803cc85f9edcd"
-	Branch = "main"
-	BuildUser = "root"
-	BuildDate = "2022-05-03@20:00:00"
-
-	version, err := Print("sidecar-injector")
-	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("sidecar-injector, version v0.4.0 (branch: main, revision: cc373f263575773f1349bbd354e803cc85f9edcd)\n  build user:       root\n  build date:       2022-05-03@20:00:00\n  go version:       %s", goVersion), version)
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
 }
 
-func TestInfo(t *testing.T) {
-	Version = "v0.4.0"
-	Revision = "cc373f263575773f1349bbd354e803cc85f9edcd"
-	Branch = "main"
+var _ = Describe("Version", func() {
+	Context("Version Information", func() {
+		It("Should print version information", func() {
+			goVersion := runtime.Version()
+			Version = "v0.4.0"
+			Revision = "cc373f263575773f1349bbd354e803cc85f9edcd"
+			Branch = "main"
+			BuildUser = "root"
+			BuildDate = "2022-05-03@20:00:00"
 
-	fields := Info()
-	require.Equal(t, []any{"version", "v0.4.0", "branch", "main", "revision", "cc373f263575773f1349bbd354e803cc85f9edcd"}, fields)
-}
+			version, err := Print("sidecar-injector")
 
-func TestBuildContext(t *testing.T) {
-	goVersion := runtime.Version()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(fmt.Sprintf("sidecar-injector, version v0.4.0 (branch: main, revision: cc373f263575773f1349bbd354e803cc85f9edcd)\n  build user:       root\n  build date:       2022-05-03@20:00:00\n  go version:       %s", goVersion)))
+		})
 
-	BuildUser = "root"
-	BuildDate = "2022-05-03@20:00:00"
+		It("Should return info", func() {
+			Version = "v0.4.0"
+			Revision = "cc373f263575773f1349bbd354e803cc85f9edcd"
+			Branch = "main"
 
-	fields := BuildContext()
-	require.Equal(t, []any{"go", goVersion, "user", "root", "date", "2022-05-03@20:00:00"}, fields)
-}
+			fields := Info()
+
+			Expect(fields).To(Equal([]any{"version", "v0.4.0", "branch", "main", "revision", "cc373f263575773f1349bbd354e803cc85f9edcd"}))
+		})
+
+		It("Should return build context", func() {
+			goVersion := runtime.Version()
+			BuildUser = "root"
+			BuildDate = "2022-05-03@20:00:00"
+
+			fields := BuildContext()
+
+			Expect(fields).To(Equal([]any{"go", goVersion, "user", "root", "date", "2022-05-03@20:00:00"}))
+		})
+	})
+})


### PR DESCRIPTION
Add test for the Sidecar Injector webhook, to tests the injection logic
and fix two bugs occured during the tests:

- The injection would fail if a sidecar must be injected, but the Pod
  doesn't have any annotations, because we were not able to set the
  status annotation in this case.
- Fix the annotations which can be used to adjust the resources of an
  injected sidecar via annotations.
